### PR TITLE
Added ChipAnimationStyle property

### DIFF
--- a/lib/src/options/choice_chips.dart
+++ b/lib/src/options/choice_chips.dart
@@ -40,6 +40,7 @@ class FastChoiceChip<T>
     this.side,
     this.surfaceTintColor,
     this.tooltip,
+    this.chipAnimationStyle,
     required this.value,
     this.visualDensity,
   }) : label = label is Widget ? label : Text(value.toString());
@@ -102,7 +103,8 @@ class FastChoiceChip<T>
   final String? tooltip;
   @override
   final VisualDensity? visualDensity;
-
+  @override
+  final ChipAnimationStyle? chipAnimationStyle;
   final bool enabled;
   final T value;
 


### PR DESCRIPTION
Hi, I don't usually contribute to projects but this one was preventing my app to compile in the Flutter 3.24.0-0.2.pre (Channel beta)

The FastChoiceChip class was missing the implementation of the chipAnimationStyle property, inherited from ChipAttributes

Sorry if I am missing something, hopefully this is helpful for others who can't build their project due to this error