### PR TITLE
added 'extends Object' now required by CupertinoSlidingSegmentedControl, Fixes #57

### DIFF
--- a/lib/src/options/segmented_control.dart
+++ b/lib/src/options/segmented_control.dart
@@ -2,12 +2,12 @@ import 'package:flutter/cupertino.dart';
 
 import '../form.dart';
 
-typedef FastSegmentedControlWidgetBuilder<T>
+typedef FastSegmentedControlWidgetBuilder<T extends Object>
     = FastWidgetBuilder<FastSegmentedControlState<T>>;
 
 /// A [FastFormField] that contains a [CupertinoSlidingSegmentedControl].
 @immutable
-class FastSegmentedControl<T> extends FastFormField<T> {
+class FastSegmentedControl<T extends Object> extends FastFormField<T> {
   FastSegmentedControl({
     FormFieldBuilder<T>? builder,
     FastSegmentedControlWidgetBuilder<T>? cupertinoErrorBuilder,
@@ -41,7 +41,7 @@ class FastSegmentedControl<T> extends FastFormField<T> {
         cupertinoPrefixBuilder =
             cupertinoPrefixBuilder ?? segmentedControlPrefixBuilder,
         super(
-          builder: builder ?? segmentedControlBuilder,
+          builder: builder ?? segmentedControlBuilder<T>,
           initialValue: initialValue ?? children.keys.first,
         );
 
@@ -58,7 +58,7 @@ class FastSegmentedControl<T> extends FastFormField<T> {
 }
 
 /// State associated with a [FastSegmentedControl] widget.
-class FastSegmentedControlState<T> extends FastFormFieldState<T> {
+class FastSegmentedControlState<T extends Object> extends FastFormFieldState<T> {
   @override
   FastSegmentedControl<T> get widget => super.widget as FastSegmentedControl<T>;
 }
@@ -66,21 +66,21 @@ class FastSegmentedControlState<T> extends FastFormFieldState<T> {
 /// A function that is the default [FastSegmentedControl.cupertinoErrorBuilder].
 ///
 /// Uses [cupertinoErrorBuilder].
-Widget? segmentedControlErrorBuilder<T>(FastSegmentedControlState<T> field) {
+Widget? segmentedControlErrorBuilder<T extends Object>(FastSegmentedControlState<T> field) {
   return cupertinoErrorBuilder(field);
 }
 
 /// A function that is the default [FastSegmentedControl.cupertinoHelperBuilder].
 ///
 /// Uses [cupertinoHelperBuilder].
-Widget? segmentedControlHelperBuilder<T>(FastSegmentedControlState<T> field) {
+Widget? segmentedControlHelperBuilder<T extends Object>(FastSegmentedControlState<T> field) {
   return cupertinoHelperBuilder(field);
 }
 
 /// A function that is the default [FastSegmentedControl.cupertinoPrefixBuilder].
 ///
 /// Uses [cupertinoPrefixBuilder].
-Widget? segmentedControlPrefixBuilder<T>(FastSegmentedControlState<T> field) {
+Widget? segmentedControlPrefixBuilder<T extends Object>(FastSegmentedControlState<T> field) {
   return cupertinoPrefixBuilder(field);
 }
 
@@ -88,7 +88,7 @@ Widget? segmentedControlPrefixBuilder<T>(FastSegmentedControlState<T> field) {
 ///
 /// Returns a [CupertinoFormRow] that contains a
 /// [CupertinoSlidingSegmentedControl] on any [TargetPlatform].
-Widget segmentedControlBuilder<T>(FormFieldState<T> field) {
+Widget segmentedControlBuilder<T extends Object>(FormFieldState<T> field) {
   field as FastSegmentedControlState<T>;
   final FastSegmentedControlState<T>(:didChange, :value, :widget) = field;
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -74,7 +74,7 @@ Finder findFastRangeSlider() => find.byType(FastRangeSlider);
 Finder findFastSegmentedButton<T>() =>
     find.byType(typeOf<FastSegmentedButton<T>>());
 
-Finder findFastSegmentedControl<T>() =>
+Finder findFastSegmentedControl<T extends Object>() =>
     find.byType(typeOf<FastSegmentedControl<T>>());
 
 Finder findFastSlider() => find.byType(FastSlider);
@@ -105,10 +105,10 @@ Finder findRow() => find.byType(Row);
 
 Finder findSegmentedButton<T>() => find.byType(typeOf<SegmentedButton<T>>());
 
-Finder findSegmentedControlButton<T>() =>
+Finder findSegmentedControlButton<T extends Object>() =>
     find.descendant(of: findSegmentedControl<T>(), matching: find.byType(Text));
 
-Finder findSegmentedControl<T>() =>
+Finder findSegmentedControl<T extends Object>() =>
     find.byType(typeOf<CupertinoSlidingSegmentedControl<T>>());
 
 Finder findSlider() => find.byType(Slider);


### PR DESCRIPTION
This PR adds `extends Object` to all T definitions that are now required to extend Object as defined by the change to cupertino's change to the definition

`class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget {`

This allows flutter_fast_forms to be used on the main/master channels.